### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/psi/app/views/formatter.py
+++ b/psi/app/views/formatter.py
@@ -134,7 +134,7 @@ def supplier_formatter(view, context, model, name):
         {'label': '开户行', 'field': 'bank_name'},
         {'label': '分行', 'field': 'bank_branch'},
     )
-    if s != None:
+    if s is not None:
         return _obj_formatter(view, context, model, value=s, model_name='supplier',
                               title=s.name, args=args, detail_args=detail_args, detail_field='paymentMethods')
     return ''


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:betterlife:flask-psi?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:betterlife:flask-psi?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)